### PR TITLE
commentsにindexを貼る

### DIFF
--- a/benchmarker/sql/schema.sql
+++ b/benchmarker/sql/schema.sql
@@ -26,5 +26,6 @@ CREATE TABLE comments (
   `post_id` int NOT NULL,
   `user_id` int NOT NULL,
   `comment` text NOT NULL,
-  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  KEY `idx_post_id_created_at` (`post_id`,`created_at` DESC)
 ) DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
```
SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3\G
SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992\G
```
DB 2大 slow queryを討伐するため
この2つを吸収できるindexは、post_id - created_at DESCが一番いいデータ保存方法に見える