### PR TITLE
postsにindexを貼る

### DIFF
--- a/benchmarker/sql/schema.sql
+++ b/benchmarker/sql/schema.sql
@@ -17,7 +17,8 @@ CREATE TABLE posts (
   `mime` varchar(64) NOT NULL,
   `imgdata` mediumblob NOT NULL,
   `body` text NOT NULL,
-  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  KEY `idx_user_id_created_at` (`user_id`,`created_at` DESC)
 ) DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS comments;


### PR DESCRIPTION
使用クエリ

```
db.Select(&results, "SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` ORDER BY `created_at` DESC")

db.Select(&results, "SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = ? ORDER BY `created_at` DESC", user.ID)

db.Select(&postIDs, "SELECT `id` FROM `posts` WHERE `user_id` = ?", user.ID)

db.Select(&results, "SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `created_at` <= ? ORDER BY `created_at` DESC", t.Format(ISO8601Format))

db.Select(&results, "SELECT * FROM `posts` WHERE `id` = ?", pid)

db.Get(&post, "SELECT * FROM `posts` WHERE `id` = ?", pid)
```